### PR TITLE
fix identity bar layout, border, and responsive behavior

### DIFF
--- a/theme/input.css
+++ b/theme/input.css
@@ -69,7 +69,7 @@ body {
 
 .page__background-top {
   position: relative;
-  height: auto;
+  height: 2rem;
   width: auto;
 }
 
@@ -175,38 +175,51 @@ body {
   clear: both;
 }
 
+/* ── Identity bar — connected pill strip ─────────────────────────────── */
+.basics__identity-bar {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  overflow: hidden;
+  border-radius: 0.5rem;
+  border: 0.2rem solid var(--color-neutral-100);
+}
+
 .basics__identity-name,
 .basics__identity-label,
 .basics__identity-mission_statement {
-  margin-top: 2.4rem;
-  line-height: 1rem;
-  padding: 0.75rem 0.25rem 0.75rem 0.25rem;
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1.25;
+  padding: 0.75rem 1.25rem;
   font-weight: 700;
-  border: 0.2rem solid var(--color-neutral-100);
-  border-radius: 0.01rem;
 }
 
 .basics__identity-name {
   background: var(--color-primary-500);
   color: var(--color-neutral-0);
-  /* border-radius: 2rem 0 0 1rem; */
-  border-radius: 0.5rem 0 0 1rem;
-  border-right: none;
+  flex-shrink: 0;
 }
 
 .basics__identity-label {
-  background: var(--color-gray-700);
+  background: var(--color-neutral-700);
   color: var(--color-neutral-0);
-  border-left: none;
-  border-right: none;
+  flex-shrink: 0;
 }
 
 .basics__identity-mission_statement {
-  background: var(--color-gray-500);
+  background: var(--color-neutral-500);
   color: var(--color-neutral-0);
-  border-radius: 0 0.5rem 1rem 0;
-  border-left: none;
+  flex: 1;
+}
+
+@media (max-width: 639px) {
+  .basics__identity-bar {
+    flex-direction: column;
+  }
 }
 
 /* Element: professional summary paragraph */
@@ -299,7 +312,7 @@ address.basics__contacts {
 }
 
 .contact--phone {
-  background-color: var(--color-gray-400);
+  background-color: var(--color-neutral-500);
   color: var(--color-neutral-0);
   line-height: 1.5rem;
   padding: 0 0.35rem;
@@ -464,7 +477,7 @@ address.basics__contacts {
    Tailwind includes the generated CSS for those classes.
    ═══════════════════════════════════════════════════════════════════════════ */
 
-@source inline("flex items-baseline justify-between gap-3 mb-3 min-w-0 gap-1 flex-wrap font-semibold text-gray-900 text-lg text-gray-400 text-sm text-gray-500 font-medium whitespace-nowrap flex-shrink-0 text-xs font-mono underline max-w-4xl mx-auto px-10 justify-center items-center gap-x-8 gap-y-1 mt-1.5 space-y-1.5 mt-3 space-y-5 break-inside-avoid mt-2 gap-1.5 py-7 space-y-6 text-gray-700 leading-relaxed -ml-2");
+@source inline("flex items-baseline justify-between gap-3 mb-3 min-w-0 gap-1 flex-wrap font-semibold text-gray-900 text-lg text-gray-400 text-sm text-gray-500 font-medium whitespace-nowrap flex-shrink-0 text-xs font-mono underline max-w-4xl mx-auto px-10 justify-center items-center gap-x-8 gap-y-1 mt-1.5 space-y-1.5 mt-3 space-y-5 break-inside-avoid mt-2 gap-1.5 py-7 space-y-6 text-gray-700 leading-relaxed");
 
 /* ═══════════════════════════════════════════════════════════════════════════
    13. PAGE CONTENT WRAPPER

--- a/theme/template.hbs
+++ b/theme/template.hbs
@@ -54,19 +54,13 @@
             <div class="basics__identity">
 
 
-                    <div class="flex w-full justify-center items-center mb-6">
-                        <div class="w-1/4">
-                            <!-- h1: primary page heading — document title for screen readers and PDF outline -->
-                            <h1 class="basics__identity-name text-accent font-mono text-xs text-center -ml-2">{{basics.name}}</h1>
-                        </div>
-                        <div class="w-1/4">
-                            <!-- role="doc-subtitle": DPUB-ARIA subtitle role for the job title / label -->
-                            <h2 class="basics__identity-label text-gray-400 font-mono text-xs text-center">{{basics.label}}</h2>
-                        </div>
-                        <div class="w-1/2">
-                            <!-- role="doc-subtitle": DPUB-ARIA subtitle role for the job title / label -->
-                            <h3 class="basics__identity-mission_statement text-gray-300 font-mono text-xs text-center italic -mr-2">{{ meta.mission_statement }}</h3>
-                        </div>
+                    <div class="basics__identity-bar">
+                        <!-- h1: primary page heading — document title for screen readers and PDF outline -->
+                        <h1 class="basics__identity-name font-mono text-xs text-center">{{basics.name}}</h1>
+                        <!-- role="doc-subtitle": DPUB-ARIA subtitle role for the job title / label -->
+                        <h2 class="basics__identity-label font-mono text-xs text-center">{{basics.label}}</h2>
+                        <!-- role="doc-subtitle": DPUB-ARIA subtitle role for the job title / label -->
+                        <h3 class="basics__identity-mission_statement font-mono text-xs text-center italic">{{meta.mission_statement}}</h3>
                     </div>
 
 
@@ -82,12 +76,12 @@
                 {{/if}}
 
                 <!-- Professional summary — full paragraph, read by screen readers and OCR -->
-                <p class="basics__summary">
+                <div class="basics__summary">
                     <div class="mb-6">
                         <span class="text-gray-600 font-medium text-sm">{{basics.summary}}</span>
                         <span class="text-accent" aria-hidden="true">&#x2665;</span>
                     </div>
-                </p>
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
- give .page__background-top an explicit height of 2rem so its absolutely-positioned ::before wave is visible above the header
- replace the old flex-column pill layout (with broken color tokens and negative margins) with a connected pill strip using .basics__identity-bar as a flex container with overflow:hidden
- move border to the container so no inter-pill seams appear at any zoom level or in pdf rendering
- add @media (max-width:639px) to stack pills vertically on mobile
- align colors to design tokens (--color-neutral-700/500 replacing stale --color-gray-700/500/400 references)
- clean up tailwind safelist (remove stale -ml-2 utility)